### PR TITLE
Add basic support for adding categories to feeds, which is added to m…

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -178,6 +178,7 @@ class Feed (object):
     # attributes that aren't in DEFAULT
     _non_default_configured_attributes = [
         'url',
+        'category',
         ]
     # attributes that are in DEFAULT
     _default_configured_attributes = [
@@ -537,6 +538,8 @@ class Feed (object):
                 ('X-RSS-URL', self._get_entry_link(entry)),
                 ('X-RSS-TAGS', self._get_entry_tags(entry)),
                 ))
+        if self.category:
+            extra_headers['X-RSS-Category'] = self.category
         # remove empty tags, etc.
         keys = {k for k, v in extra_headers.items() if v is None}
         for key in keys:


### PR DESCRIPTION
…essage headers as X-RSS-Category. This can in turn be used by software like procmail to sort feeds into different folders based on content. E.g., you can set Games for gaming-related feeds to, News for general news feeds, etc., and have content from all feeds with that category sent to the same folder.